### PR TITLE
Arsenic can't be used with 0 discards

### DIFF
--- a/mod/data/CA_Alchemicals.lua
+++ b/mod/data/CA_Alchemicals.lua
@@ -286,7 +286,7 @@ function CodexArcanum.INIT.CA_Alchemicals()
     alchemy_arsenic:register()
             
     function CodexArcanum.Alchemicals.c_alchemy_arsenic.can_use(card)
-        return true
+        return G.GAME.current_round.discards_left ~= 0
     end
 
     function CodexArcanum.Alchemicals.c_alchemy_arsenic.use(card, area, copier)


### PR DESCRIPTION
Prevents an edge case where using Arsenic with 0 discards would result in 0 hands left, but would still allow you to play a hand. Once played, it will count down to -1 instead.

Fixes #3 