### PR TITLE
Rename Codex SMODS.Booster for 1.0.0 compat

### DIFF
--- a/mod/CA_Overrides.lua
+++ b/mod/CA_Overrides.lua
@@ -932,7 +932,7 @@ function Game:init_item_prototypes()
     alchemical:register()
   end
 
-  for _, tag in pairs(SMODS.Tags) do
+  for _, tag in pairs(SMODS.CATags) do
     tag:register()
   end
   SMODS.LOAD_LOC()

--- a/mod/CA_Overrides.lua
+++ b/mod/CA_Overrides.lua
@@ -924,7 +924,7 @@ function Game:init_item_prototypes()
   G.P_CENTER_POOLS.Alchemical = {}
   G.localization.descriptions.Alchemical = {}
 
-  for _, booster in pairs(SMODS.Boosters) do
+  for _, booster in pairs(SMODS.CABoosters) do
     booster:register()
   end
 

--- a/mod/api/BoosterPackRegister.lua
+++ b/mod/api/BoosterPackRegister.lua
@@ -2,8 +2,8 @@
 -- BOOSTER API
 ------------------------------------
 
-SMODS.Boosters = {}
-SMODS.Booster = {
+SMODS.CABoosters = {}
+SMODS.CABooster = {
   	name = "",
   	slug = "",
 	cost = 4,
@@ -15,7 +15,7 @@ SMODS.Booster = {
     atlas = 'Booster'
 }
 
-function SMODS.Booster:new(name, slug, config, pos, cost, discovered, weight, kind, atlas)
+function SMODS.CABooster:new(name, slug, config, pos, cost, discovered, weight, kind, atlas)
     o = {}
     setmetatable(o, self)
     self.__index = self
@@ -35,8 +35,8 @@ function SMODS.Booster:new(name, slug, config, pos, cost, discovered, weight, ki
 	return o
 end
 
-function SMODS.Booster:register()
-	SMODS.Boosters[self.slug] = self
+function SMODS.CABooster:register()
+	SMODS.CABoosters[self.slug] = self
 
 	local minId = table_length(G.P_CENTER_POOLS['Booster']) + 1
     local id = 0

--- a/mod/api/TagAPI.lua
+++ b/mod/api/TagAPI.lua
@@ -2,8 +2,8 @@
 -- TAGS API
 ------------------------------------
 
-SMODS.Tags = {}
-SMODS.Tag = {
+SMODS.CATags = {}
+SMODS.CATag = {
 	name = "",
 	slug = "",
 	config = {},
@@ -13,7 +13,7 @@ SMODS.Tag = {
 	min_ante = nil
 }
 
-function SMODS.Tag:new(name, slug, config, pos, loc_txt, min_ante, discovered, atlas)
+function SMODS.CATag:new(name, slug, config, pos, loc_txt, min_ante, discovered, atlas)
 	o = {}
 	setmetatable(o, self)
 	self.__index = self
@@ -34,8 +34,8 @@ function SMODS.Tag:new(name, slug, config, pos, loc_txt, min_ante, discovered, a
 	return o
 end
 
-function SMODS.Tag:register()
-	SMODS.Tags[self.slug] = self
+function SMODS.CATag:register()
+	SMODS.CATags[self.slug] = self
 	local minId = table_length(G.P_CENTER_POOLS['Tag']) + 1
 	local id = 0
 	local i = 0
@@ -189,7 +189,7 @@ function Tag:apply_to_run(_context)
 	local ret_val = apply_to_runref(self, _context)
 	if not self.triggered and self.config.type == _context.type then
 		local key = self.key
-        local tag_obj = SMODS.Tags[key]
+        local tag_obj = SMODS.CATags[key]
         if tag_obj and tag_obj.apply and type(tag_obj.apply) == "function" then
             local o = tag_obj.apply(self, _context)
             if o then return o end

--- a/mod/data/CA_BoosterPacks.lua
+++ b/mod/data/CA_BoosterPacks.lua
@@ -29,11 +29,11 @@ function CodexArcanum.INIT.CA_BoosterPacks()
     }
   
     SMODS.Sprite:new("ca_booster_atlas", CodexArcanum.mod.path, "ca_booster_atlas.png", 71, 95, "asset_atli"):register();
-    SMODS.Booster:new("Alchemy Pack", "alchemy_normal_1", {extra = 2, choose = 1}, { x = 0, y = 0 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
-    SMODS.Booster:new("Alchemy Pack", "alchemy_normal_2", {extra = 2, choose = 1}, { x = 1, y = 0 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
-    SMODS.Booster:new("Alchemy Pack", "alchemy_normal_3", {extra = 2, choose = 1}, { x = 2, y = 0 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
-    SMODS.Booster:new("Alchemy Pack", "alchemy_normal_4", {extra = 2, choose = 1}, { x = 3, y = 0 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
-    SMODS.Booster:new("Jumbo Alchemy Pack", "alchemy_jumbo_1", {extra = 4, choose = 1}, { x = 0, y = 1 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
-    SMODS.Booster:new("Jumbo Alchemy Pack", "alchemy_jumbo_2", {extra = 4, choose = 1}, { x = 1, y = 1 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
-    SMODS.Booster:new("Mega Alchemy Pack", "alchemy_mega_1", {extra = 4, choose = 2}, { x = 2, y = 1 }, 4, false, 0.25, "Celestial", "ca_booster_atlas"):register()
+    SMODS.CABooster:new("Alchemy Pack", "alchemy_normal_1", {extra = 2, choose = 1}, { x = 0, y = 0 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
+    SMODS.CABooster:new("Alchemy Pack", "alchemy_normal_2", {extra = 2, choose = 1}, { x = 1, y = 0 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
+    SMODS.CABooster:new("Alchemy Pack", "alchemy_normal_3", {extra = 2, choose = 1}, { x = 2, y = 0 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
+    SMODS.CABooster:new("Alchemy Pack", "alchemy_normal_4", {extra = 2, choose = 1}, { x = 3, y = 0 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
+    SMODS.CABooster:new("Jumbo Alchemy Pack", "alchemy_jumbo_1", {extra = 4, choose = 1}, { x = 0, y = 1 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
+    SMODS.CABooster:new("Jumbo Alchemy Pack", "alchemy_jumbo_2", {extra = 4, choose = 1}, { x = 1, y = 1 }, 4, false, 1, "Celestial", "ca_booster_atlas"):register()
+    SMODS.CABooster:new("Mega Alchemy Pack", "alchemy_mega_1", {extra = 4, choose = 2}, { x = 2, y = 1 }, 4, false, 0.25, "Celestial", "ca_booster_atlas"):register()
 end

--- a/mod/data/CA_Others.lua
+++ b/mod/data/CA_Others.lua
@@ -87,11 +87,11 @@ function CodexArcanum.INIT.CA_Others()
     }
         }
         
-        local tag_elemental = SMODS.Tag:new("Elemental Tag", "elemental", {type = 'new_blind_choice'}, { x = 0, y = 0 }, tag_elemental_def)
+        local tag_elemental = SMODS.CATag:new("Elemental Tag", "elemental", {type = 'new_blind_choice'}, { x = 0, y = 0 }, tag_elemental_def)
         SMODS.Sprite:new("tag_elemental", CodexArcanum.mod.path, "tag_elemental.png", 34, 34, "asset_atli"):register();
         tag_elemental:register()
 
-        function SMODS.Tags.tag_elemental.apply(tag, context)
+        function SMODS.CATags.tag_elemental.apply(tag, context)
             if context.type == 'new_blind_choice' then 
                 local lock = tag.ID
                 G.CONTROLLER.locks[lock] = true


### PR DESCRIPTION
This fix removes the collision between Codex's `SMODS.Booster`/`SMODS.Tag` and the Steamodded API of the same names in 1.0.0 by renaming to `SMODS.CABooster`/`SMODS.CATag`